### PR TITLE
Install open_cdm_adapter.h

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -10,7 +10,8 @@ sparkle_cdm_sources = [
 ]
 
 sparkle_cdm_headers = [
-  'open_cdm.h'
+  'open_cdm.h',
+  'open_cdm_adapter.h'
 ]
 
 sparkle_cdm_deps = [


### PR DESCRIPTION
This is a public header that WebKit depends on