### PR TITLE
Move external modules to libdir

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -9,7 +9,7 @@ project('sparkle-cdm', 'cpp',
 
 config_h = configuration_data()
 config_h.set_quoted('PACKAGE_VERSION', meson.project_version())
-config_h.set_quoted('EXTERNAL_MODULE_PATH', get_option('prefix') / get_option('libexecdir') / 'sparkle-cdm')
+config_h.set_quoted('EXTERNAL_MODULE_PATH', get_option('prefix') / get_option('libdir') / 'sparkle-cdm')
 
 configure_file(output: 'sparkle-cdm-config.h',
         configuration: config_h)


### PR DESCRIPTION
libexecdir is for executables, not shared objects. Instead, let's
install into libdir/sparkle-cdm.